### PR TITLE
Fix reusage of reference for unknown nodes

### DIFF
--- a/LSS/XML2Array.php
+++ b/LSS/XML2Array.php
@@ -157,6 +157,8 @@ class XML2Array {
 					$output[static::$prefix_attributes.'attributes'] = $a;
 				}
 				break;
+			default:
+				$output = '';
 		}
 		return $output;
     }


### PR DESCRIPTION
The reference to $output was overwritten by nodes not covered by the switch construct.

Example to test:
```xml
<root>
  <Nodes>
    <Node One="1" Two="2" />
    <Node Two="2" Three="3" />
            <!-- Content omitted -->
    <Node Three="3" Four="4" />
  </Nodes>
</root>
```

Array without patch:
```php
[
  'root' => [
    'Nodes' => [
      'Node' => [
        '@value'    => '',
        '@attributes' => [
          'Three' => '3',
          'Four'  => '4',
        ],
      ],
    ],
  ],
];
```

Array with patch:
```js
[
  'root' => [
    'Nodes' => [
      'Node' => [
        0 => [
          '@value'    => '',
          '@attributes' => [
            'One' => '1',
            'Two' => '2',
          ],
        ],
        1 => [
          '@value'    => '',
          '@attributes' => [
            'Two'   => '2',
            'Three' => '3',
          ],
        ],
        2 => [
          '@value'    => '',
          '@attributes' => [
            'Three' => '3',
            'Four'  => '4',
          ],
        ],
      ],
    ],
  ],
];
```