### PR TITLE
PHP 8.1 - DOMDocument::createTextNode

### DIFF
--- a/LSS/Array2XML.php
+++ b/LSS/Array2XML.php
@@ -170,7 +170,7 @@ class Array2XML {
 
         // after we are done with all the keys in the array (if it is one)
         // we check if it has any text value, if yes, append it.
-        if (!is_array($arr)) {
+        if (!is_array($arr) && $arr) {
             $node->appendChild($xml->createTextNode(self::bool2str($arr)));
         }
 


### PR DESCRIPTION
Dear Array2XML people,

I found an issue as I upgraded to PHP 8.1, the following exception came up from line 174:
DOMDocument::createTextNode(): Passing null to parameter 1 ($data) of type string is deprecated

It might have to do with the following, from https://www.php.net/manual/en/domdocument.createtextnode
"Version 8.1.0 - In case of an error, a DomException is thrown now. Previously, false was returned."

I found a quick fix that works just fine in my situation...
Please have a look, it might be the correct way! 

Thank you,